### PR TITLE
[FIX JENKINS-27042] Use TrueZIP to access archive

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,11 @@
     <name>Compress Artifacts Plugin</name>
     <description>Keeps build artifacts compressed to save disk space on the master.</description>
     <url>https://wiki.jenkins-ci.org/display/JENKINS/Compress+Artifacts+Plugin</url>
+
+    <properties>
+        <truezip.version>7.7.8</truezip.version>
+    </properties>
+
     <licenses>
         <license>
             <name>MIT License</name>
@@ -22,7 +27,7 @@
         <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
-      <tag>HEAD</tag>
+        <tag>HEAD</tag>
     </scm>
     <developers>
       <developer>
@@ -31,6 +36,18 @@
         <email>ogondza@gmail.com</email>
       </developer>
     </developers>
+    <dependencies>
+        <dependency>
+            <groupId>de.schlichtherle.truezip</groupId>
+            <artifactId>truezip-driver-zip</artifactId>
+            <version>${truezip.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>de.schlichtherle.truezip</groupId>
+            <artifactId>truezip-file</artifactId>
+            <version>${truezip.version}</version>
+        </dependency>
+    </dependencies>
     <repositories>
         <repository>
             <id>repo.jenkins-ci.org</id>

--- a/src/main/java/org/jenkinsci/plugins/compress_artifacts/ZipStorage.java
+++ b/src/main/java/org/jenkinsci/plugins/compress_artifacts/ZipStorage.java
@@ -52,6 +52,8 @@ import org.apache.tools.ant.types.selectors.SelectorUtils;
 import de.schlichtherle.truezip.file.TArchiveDetector;
 import de.schlichtherle.truezip.file.TFile;
 import de.schlichtherle.truezip.file.TVFS;
+import de.schlichtherle.truezip.zip.ZipEntry;
+import de.schlichtherle.truezip.zip.ZipFile;
 
 final class ZipStorage extends VirtualFile {
 
@@ -281,10 +283,21 @@ final class ZipStorage extends VirtualFile {
             zf.close();
             throw new FileNotFoundException(path + " (No such file or directory)");
         }
-        return new FilterInputStream(zf.getInputStream(entry)) {
-            @Override public void close() throws IOException {
-                zf.close();
-            }
-        };
+
+        return new EntryInputStream(zf, entry);
+    }
+
+    private static final class EntryInputStream extends FilterInputStream {
+        private final @Nonnull ZipFile archive;
+        private EntryInputStream(ZipFile archive, ZipEntry entry) throws IOException {
+            super(archive.getInputStream(entry));
+            this.archive = archive;
+        }
+
+        @Override
+        public void close() throws IOException {
+            super.close();
+            archive.close();
+        }
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/compress_artifacts/ZipStorage.java
+++ b/src/main/java/org/jenkinsci/plugins/compress_artifacts/ZipStorage.java
@@ -30,25 +30,28 @@ import hudson.model.BuildListener;
 
 import java.io.File;
 import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
 import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipFile;
+
+import javax.annotation.Nonnull;
 
 import jenkins.util.VirtualFile;
 
 import org.apache.commons.httpclient.URIException;
 import org.apache.commons.httpclient.util.URIUtil;
 import org.apache.tools.ant.types.selectors.SelectorUtils;
+
+import de.schlichtherle.truezip.file.TArchiveDetector;
+import de.schlichtherle.truezip.file.TFile;
+import de.schlichtherle.truezip.file.TVFS;
 
 final class ZipStorage extends VirtualFile {
 
@@ -59,14 +62,21 @@ final class ZipStorage extends VirtualFile {
     // TODO support updating entries
     static void archive(File archive, FilePath workspace, Launcher launcher, BuildListener listener, Map<String,String> artifacts) throws IOException, InterruptedException {
         // Use temporary file for writing, rename when done
-        File writingArchive = new File(archive.getAbsolutePath() + ".writing");
-        OutputStream os = new FileOutputStream(writingArchive);
-        try {
-            workspace.zip(os, new FilePath.ExplicitlySpecifiedDirScanner(artifacts));
-        } finally {
-            os.close();
+        File tempArchive = new File(archive.getAbsolutePath() + ".writing.zip");
+
+        TFile zip = new TFile(tempArchive, new TArchiveDetector("zip"));
+        zip.mkdir(); // Create new archive file
+        for (Entry<String, String> afs: artifacts.entrySet()) {
+            FilePath src = workspace.child(afs.getKey());
+            TFile dst = new TFile(zip, afs.getValue(), TArchiveDetector.NULL);
+            if (src.isDirectory()) {
+                dst.mkdirs();
+            } else {
+                TFile.cp(src.read(), dst);
+            }
         }
-        writingArchive.renameTo(archive);
+        TVFS.umount(zip);
+        tempArchive.renameTo(archive);
     }
 
     static boolean delete(File archive) throws IOException, InterruptedException {
@@ -206,7 +216,7 @@ final class ZipStorage extends VirtualFile {
             while (entries.hasMoreElements()) {
             	ZipEntry entry = entries.nextElement();
             	if ((! entry.isDirectory()) && entry.getName().startsWith(path)) {
-            		String name = entry.toString().substring(path.length());
+            		String name = entry.getName().substring(path.length());
             		if (SelectorUtils.match(glob, name)) {
             			files.add(name);
             		}
@@ -257,7 +267,7 @@ final class ZipStorage extends VirtualFile {
     @Override public boolean canRead() throws IOException {
         return true;
     }
-    
+
     @Override public InputStream open() throws IOException {
         if (!archive.exists()) throw new FileNotFoundException(path + " (No such file or directory)");
 

--- a/src/test/java/org/jenkinsci/plugins/compress_artifacts/CompressArtifactsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/compress_artifacts/CompressArtifactsTest.java
@@ -120,8 +120,12 @@ public class CompressArtifactsTest {
 
         // read the content
         for (Run<FreeStyleProject, FreeStyleBuild>.Artifact a: artifacts) {
-            String content = IOUtils.toString(build.getArtifactManager().root().child(a.relativePath).open());
-            assertThat(content, endsWith("txt"));
+            final InputStream artifactStream = build.getArtifactManager().root().child(a.relativePath).open();
+            try {
+                assertThat(IOUtils.toString(artifactStream), endsWith("txt"));
+            } finally {
+                artifactStream.close();
+            }
         }
     }
 


### PR DESCRIPTION
[JENKINS-27042](https://issues.jenkins-ci.org/browse/JENKINS-27042)

TrueZIP should work fine later when we decide to support `VirtualFile#delete` or append to archive.

@jglick review appreciated.