### PR TITLE
Refresh plugin

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -2,6 +2,6 @@
   <extension>
     <groupId>io.jenkins.tools.incrementals</groupId>
     <artifactId>git-changelist-maven-extension</artifactId>
-    <version>1.0-beta-3</version>
+    <version>1.4</version>
   </extension>
 </extensions>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,34 @@
+## Changelog
+
+### Version 1.7
+
+- Optimize artifact archiving. ([JENKINS-28862](https://issues.jenkins-ci.org/browse/JENKINS-28862))
+- Fix regression of [JENKINS-27042](https://issues.jenkins-ci.org/browse/JENKINS-27042) from 1.6.
+
+### Version 1.5
+
+- Unable to compress artifacts with non-IBM437 characters in filename. Regression introduced in 1.4. ([JENKINS-27522](https://issues.jenkins-ci.org/browse/JENKINS-27522))
+
+### Version 1.4
+
+- java.util.zip.ZipException thrown when reading artifacts from archive larger than 4G. ([JENKINS-27042](https://issues.jenkins-ci.org/browse/JENKINS-27042))
+
+Stability issues
+
+Before this version, plugin is not able to serve artifacts when archive exceeds 4G in size, it leads to JVM crashes on java 6. ([JENKINS-27042](https://issues.jenkins-ci.org/browse/JENKINS-27042))
+
+### Version 1.3
+
+- Avoid ZipException thrown when accessing artifiacts while archiving. [4720879](https://github.com/jenkinsci/compress-artifacts-plugin/commit/47208791705ed6d77bbc4931fe8f1f4517c9b9bc)
+
+### Version 1.2
+
+- Handle special characters in artifact filename correctly. [JENKINS-26858](https://issues.jenkins-ci.org/browse/JENKINS-26858)
+
+### Version 1.1
+
+- Supporting "download artifacts as ZIP".
+
+### Version 1.0
+
+- Initial version. See [JENKINS-6229](https://issues.jenkins-ci.org/browse/JENKINS-6229) for background. Not yet implemented: adding artifacts in multiple rounds; downloading ZIPs of artifacts.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# Compress Artifacts
+
+Keeps build artifacts compressed to save disk space on the controller.
+
+Adds an option to compress build artifacts (currently in a ZIP file only) when stored on the controller.
+To use, you must request this option in the Jenkins global configuration screen (*Artifact Management for Builds* section).
+
+Artifacts produced before the plugin was installed/configured will not be compressed, though they will be served correctly.
+
+### Compatibility issues
+
+Some other plugins do not yet support nonstandard artifact storage.
+In particular, Copy Artifact will be broken. ([JENKINS-22637](https://issues.jenkins-ci.org/browse/JENKINS-22637))

--- a/pom.xml
+++ b/pom.xml
@@ -1,9 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.15</version>
+        <version>4.49</version>
         <relativePath />
     </parent>
     <artifactId>compress-artifacts</artifactId>
@@ -11,31 +12,28 @@
     <packaging>hpi</packaging>
     <name>Compress Artifacts Plugin</name>
     <description>Keeps build artifacts compressed to save disk space on the master.</description>
-    <url>https://wiki.jenkins-ci.org/display/JENKINS/Compress+Artifacts+Plugin</url>
+    <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
 
     <properties>
         <revision>1.11</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>2.121.1</jenkins.version>
-        <java.level>8</java.level>
-        <concurrency>2</concurrency>
-        <surefire.useFile>false</surefire.useFile>
-        <findbugs.failOnError>false</findbugs.failOnError>
-
+        <jenkins.version>2.319.3</jenkins.version>
+        <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
         <truezip.version>7.7.10</truezip.version>
-        <workflow-api-plugin.version>2.28</workflow-api-plugin.version>
+        <!-- TODO fix violations -->
+        <spotbugs.threshold>High</spotbugs.threshold>
     </properties>
 
     <licenses>
         <license>
             <name>MIT License</name>
-            <url>http://www.opensource.org/licenses/mit-license.php</url>
+            <url>https://opensource.org/licenses/MIT</url>
         </license>
     </licenses>
     <scm>
-        <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
-        <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
-        <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
+        <connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
+        <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
+        <url>https://github.com/${gitHubRepo}</url>
         <tag>${scmTag}</tag>
     </scm>
     <developers>
@@ -45,6 +43,19 @@
         <email>ogondza@gmail.com</email>
       </developer>
     </developers>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.jenkins.tools.bom</groupId>
+                <artifactId>bom-2.319.x</artifactId>
+                <version>1654.vcb_69d035fa_20</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>de.schlichtherle.truezip</groupId>
@@ -63,20 +74,22 @@
             <version>${truezip.version}</version>
         </dependency>
         <dependency>
+            <groupId>io.jenkins.plugins</groupId>
+            <artifactId>commons-httpclient3-api</artifactId>
+            <version>3.1-3</version>
+        </dependency>
+        <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>structs</artifactId>
-            <version>1.14</version>
+            <artifactId>apache-httpcomponents-client-4-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-api</artifactId>
-            <version>${workflow-api-plugin.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-api</artifactId>
-            <version>${workflow-api-plugin.version}</version>
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
@@ -89,13 +102,11 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>ssh-slaves</artifactId>
-            <version>1.26</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>jdk-tool</artifactId>
-            <version>1.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <version>${revision}${changelist}</version>
     <packaging>hpi</packaging>
     <name>Compress Artifacts Plugin</name>
-    <description>Keeps build artifacts compressed to save disk space on the master.</description>
+    <description>Keeps build artifacts compressed to save disk space on the controller.</description>
     <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
 
     <properties>

--- a/src/main/resources/index.html
+++ b/src/main/resources/index.html
@@ -1,3 +1,3 @@
 <div>
-    Keeps build artifacts compressed to save disk space on the master.
+    Keeps build artifacts compressed to save disk space on the controller.
 </div>

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,0 +1,4 @@
+<?jelly escape-by-default='true'?>
+<div>
+    Keeps build artifacts compressed to save disk space on the controller.
+</div>


### PR DESCRIPTION
This plugin currently consumes the deprecated Commons HttpClient 3.x API via Jenkins core. In https://github.com/jenkinsci/jenkins/pull/7312 we plan to remove this library from Jenkins core. To ensure this plugin continues to work, this PR prepares the plugin for https://github.com/jenkinsci/jenkins/pull/7312 by adding a dependency on the [Commons HttpClient 3.x API plugin](https://plugins.jenkins.io/commons-httpclient3-api/). Apparently something also needs `apache-httpcomponents-client-4-api`, as `InjectedTest` logged `java.lang.NoClassDefFoundError: org/apache/http/HttpEntity` unless I also added that plugin as a dependency. While we were here, we refreshed the build toolchain and dependencies to recent versions. CC @jglick @olivergondza