### PR TITLE
Remove commons-httpclient3-api plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 
     <properties>
         <changelist>999999-SNAPSHOT</changelist>
-        <jenkins.version>2.319.3</jenkins.version>
+        <jenkins.version>2.414.3</jenkins.version>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
         <truezip.version>7.7.10</truezip.version>
         <!-- TODO fix violations -->
@@ -47,8 +47,8 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.319.x</artifactId>
-                <version>1654.vcb_69d035fa_20</version>
+                <artifactId>bom-2.414.x</artifactId>
+                <version>2977.vdf61ecb_fb_e2d</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -73,16 +73,6 @@
             <version>${truezip.version}</version>
         </dependency>
         <dependency>
-            <groupId>io.jenkins.plugins</groupId>
-            <artifactId>commons-httpclient3-api</artifactId>
-            <version>3.1-3</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>apache-httpcomponents-client-4-api</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-api</artifactId>
             <scope>test</scope>
@@ -96,7 +86,7 @@
         <dependency>
             <groupId>org.jenkins-ci.test</groupId>
             <artifactId>docker-fixtures</artifactId>
-            <version>166.v912b_95083ffe</version>
+            <version>190.vd6a_e600cb_775</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/org/jenkinsci/plugins/compress_artifacts/TrueZipArchiver.java
+++ b/src/main/java/org/jenkinsci/plugins/compress_artifacts/TrueZipArchiver.java
@@ -25,7 +25,6 @@
 package org.jenkinsci.plugins.compress_artifacts;
 
 import hudson.util.FileVisitor;
-import hudson.util.IOUtils;
 import hudson.util.io.Archiver;
 import hudson.util.io.ArchiverFactory;
 

--- a/src/main/java/org/jenkinsci/plugins/compress_artifacts/ZipStorage.java
+++ b/src/main/java/org/jenkinsci/plugins/compress_artifacts/ZipStorage.java
@@ -37,6 +37,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
 import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.Map;
@@ -48,8 +49,7 @@ import javax.annotation.Nonnull;
 
 import jenkins.util.VirtualFile;
 
-import org.apache.commons.httpclient.URIException;
-import org.apache.commons.httpclient.util.URIUtil;
+import org.springframework.web.util.UriUtils;
 
 import de.schlichtherle.truezip.zip.ZipEntry;
 import de.schlichtherle.truezip.zip.ZipFile;
@@ -95,10 +95,8 @@ final class ZipStorage extends VirtualFile {
         try {
             // If no scheme is provided, beginning of the path is parsed as the scheme causing validation problems.
             // Using some scheme to workaround that + prepending prefix to avoid empty URI path.
-            return new URI("zip", "./" + URIUtil.encodePath(path), null);
+            return new URI("zip", "./" + UriUtils.encodePath(path, StandardCharsets.UTF_8), null);
         } catch (URISyntaxException x) {
-            throw new AssertionError(x);
-        } catch (URIException x) {
             throw new AssertionError(x);
         }
     }

--- a/src/test/java/org/jenkinsci/plugins/compress_artifacts/CompressArtifactsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/compress_artifacts/CompressArtifactsTest.java
@@ -27,7 +27,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.endsWith;
 import static org.junit.Assert.assertEquals;
 
-import com.google.common.io.NullOutputStream;
 import hudson.FilePath;
 import hudson.Functions;
 import hudson.Launcher;
@@ -53,6 +52,7 @@ import jenkins.model.Jenkins;
 import jenkins.model.WorkspaceWriter;
 
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.io.output.NullOutputStream;
 import org.hamcrest.Matchers;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assume.*;
@@ -240,7 +240,7 @@ public class CompressArtifactsTest {
         FreeStyleBuild build = j.buildAndAssertSuccess(p);
         InputStream out = build.getArtifactManager().root().child("out").open();
         try {
-            IOUtils.copy(out, new NullOutputStream());
+            IOUtils.copy(out, NullOutputStream.INSTANCE);
         } finally {
              out.close();
         }


### PR DESCRIPTION
Remove the deprecated / outdated httpclient3-api plugin. On further investigation, httpclient not required in the first place.

### Testing done

Validated via `mvn verify`

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
