### PR TITLE
[JENKINS-74977] Require Jenkins 2.452.4, depend on commons compress API plugin

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,8 +1,10 @@
-/* `buildPlugin` step provided by: https://github.com/jenkins-infra/pipeline-library */
+/*
+ See the documentation for more options:
+ https://github.com/jenkins-infra/pipeline-library/
+*/
 buildPlugin(
-  useContainerAgent: false,
+  useContainerAgent: false, // CompressingArtifactManagerFactoryTest use a container image
   configurations: [
-    [platform: 'linux', jdk: 11],
-    [platform: 'linux', jdk: 17],
-    [platform: 'windows', jdk: 11],
+    [platform: 'linux', jdk: 21],
+    [platform: 'windows', jdk: 17],
 ])

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.82</version>
+        <version>4.88</version>
         <relativePath />
     </parent>
     <artifactId>compress-artifacts</artifactId>
@@ -16,7 +16,8 @@
 
     <properties>
         <changelist>999999-SNAPSHOT</changelist>
-        <jenkins.version>2.414.3</jenkins.version>
+        <jenkins.baseline>2.452</jenkins.baseline>
+        <jenkins.version>${jenkins.baseline}.4</jenkins.version>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
         <truezip.version>7.7.10</truezip.version>
         <!-- TODO fix violations -->
@@ -47,8 +48,8 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.414.x</artifactId>
-                <version>2982.vdce2153031a_0</version>
+                <artifactId>bom-${jenkins.baseline}.x</artifactId>
+                <version>3790.va_b_a_2d26d2b_69</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -56,6 +57,10 @@
     </dependencyManagement>
 
     <dependencies>
+        <dependency>
+            <groupId>io.jenkins.plugins</groupId>
+            <artifactId>commons-compress-api</artifactId>
+        </dependency>
         <dependency>
             <groupId>de.schlichtherle.truezip</groupId>
             <artifactId>truezip-driver-zip</artifactId>

--- a/src/main/java/org/jenkinsci/plugins/compress_artifacts/TrueZipArchiver.java
+++ b/src/main/java/org/jenkinsci/plugins/compress_artifacts/TrueZipArchiver.java
@@ -51,6 +51,10 @@ final /*pacakge*/ class TrueZipArchiver extends Archiver {
         zip = new ZipOutputStream(out, Charset.defaultCharset());
     }
 
+    /*package*/ TrueZipArchiver(OutputStream out, Charset filenamesEncoding) {
+        zip = new ZipOutputStream(out, filenamesEncoding);
+    }
+
     @Override
     public void visit(final File f, final String _relativePath) throws IOException {
         // int mode = IOUtils.mode(f); // TODO
@@ -100,6 +104,10 @@ final /*pacakge*/ class TrueZipArchiver extends Archiver {
         @Override
         public Archiver create(OutputStream out) throws IOException {
             return new TrueZipArchiver(out);
+        }
+        @Override
+        public Archiver create(OutputStream out, Charset filenamesEncoding) throws IOException {
+            return new TrueZipArchiver(out, filenamesEncoding);
         }
     }; 
 }

--- a/src/test/java/org/jenkinsci/plugins/compress_artifacts/ZipStorageTest.java
+++ b/src/test/java/org/jenkinsci/plugins/compress_artifacts/ZipStorageTest.java
@@ -290,16 +290,12 @@ public class ZipStorageTest {
         };
 
         compressor.start();
-        try {
-            Thread.sleep(1000);
+        Thread.sleep(200);
 
-            assertTrue(compressor.isAlive());
+        assertTrue(compressor.isAlive());
 
-            assertArrayEquals(new String[0], zs.list());
-            assertArrayEquals(new VirtualFile[0], zs.list("*"));
-        } finally {
-            compressor.stop();
-        }
+        assertArrayEquals(new String[0], zs.list());
+        assertArrayEquals(new VirtualFile[0], zs.list("*"));
     }
 
     @Test // This can happen when it was not yet (fully) written or it was deleted


### PR DESCRIPTION
## [JENKINS-74977](https://issues.jenkins.io/browse/JENKINS-74977) Require Jenkins 2.452.4, depend on commons compress API plugin

Jenkins 2.489 removes the commons compress library from Jenkins core.  This plugin depended on the commons compress library being provided by Jenkins core in order to satisfy the transitive dependency from truezip-driver-zip.  Make the plugin depend on commons-compress-api plugin instead of commons-core from Jenkins core so that the plugin can run on Jenkins versions 2.489 and later.

Jenkins 2.452.4 was selected as the minimum Jenkins version because:

* 75% of installations of the most recent release are [already running 2.452.4 or newer](https://old.stats.jenkins.io/pluginversions/compress-artifacts.html)
* 2.452.4 is a [recommended minimum Jenkins version](https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/#currently-recommended-versions)
* 2.452.4 is the release that fixes [critical security vulnerability SECURITY-3430](https://www.jenkins.io/security/advisory/2024-08-07/#SECURITY-3430)
* The commons-compress-api plugin is not available in the plugin BOM until 2.426.x, so some upgrade of the minimum Jenkins version is required.  Better to choose a recommended version than an older version

This issue also blocks the update of the Jenkins acceptance test harness to use Jenkins 2.489.  The pull request that fails due to the compress artifacts plugin is:

* https://github.com/jenkinsci/acceptance-test-harness/pull/1860

Also updates the Jenkinsfile to test with Java 17 and Java 21, since Jenkins core releases no longer support Java 11.

Supersedes:

* #29 

Would very much appreciate a rapid merge and release of this change so that the acceptance test harness can pass again.

### Testing done

Confirmed that the [109.v98a_db_d3cb_72c release of the plugin](https://github.com/jenkinsci/compress-artifacts-plugin/releases/tag/109.v98a_db_d3cb_72c) fails when loaded into Jenkins 2.489 after enabling Artifact Management for Builds with the "Compress Artifacts" setting.  The Pipeline looks like this:

```
pipeline {
    agent any
    stages {
	stage('Archive-datefile') {
	    steps {
		sh 'date >> datefile.txt'
		archiveArtifacts artifacts: 'datefile.txt'
	    }
	}
    }
}
```

Confirmed that the same Pipeline works correctly with the updated version of the plugin from this change.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
