### PR TITLE
Require Jenkins 2.504.1 and Jakarta EE 9

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -2,6 +2,6 @@
   <extension>
     <groupId>io.jenkins.tools.incrementals</groupId>
     <artifactId>git-changelist-maven-extension</artifactId>
-    <version>1.8</version>
+    <version>1.10</version>
   </extension>
 </extensions>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ Before this version, plugin is not able to serve artifacts when archive exceeds 
 
 ### Version 1.3
 
-- Avoid ZipException thrown when accessing artifiacts while archiving. [4720879](https://github.com/jenkinsci/compress-artifacts-plugin/commit/47208791705ed6d77bbc4931fe8f1f4517c9b9bc)
+- Avoid ZipException thrown when accessing artifacts while archiving. [4720879](https://github.com/jenkinsci/compress-artifacts-plugin/commit/47208791705ed6d77bbc4931fe8f1f4517c9b9bc)
 
 ### Version 1.2
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.88</version>
+        <version>5.18</version>
         <relativePath />
     </parent>
     <artifactId>compress-artifacts</artifactId>
@@ -16,8 +16,8 @@
 
     <properties>
         <changelist>999999-SNAPSHOT</changelist>
-        <jenkins.baseline>2.452</jenkins.baseline>
-        <jenkins.version>${jenkins.baseline}.4</jenkins.version>
+        <jenkins.baseline>2.504</jenkins.baseline>
+        <jenkins.version>${jenkins.baseline}.1</jenkins.version>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
         <!-- TODO fix violations -->
         <spotbugs.threshold>High</spotbugs.threshold>
@@ -41,7 +41,7 @@
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
                 <artifactId>bom-${jenkins.baseline}.x</artifactId>
-                <version>3790.va_b_a_2d26d2b_69</version>
+                <version>5015.vb_52d36583443</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -57,14 +57,15 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-api</artifactId>
+            <!-- TODO: remove -->
+            <version>1377.vf606866f592b_</version>
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.jenkins-ci.test</groupId>
-            <artifactId>docker-fixtures</artifactId>
-            <version>200.v22a_e8766731c</version>
-            <scope>test</scope>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <version>1.21.3</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
                 <artifactId>bom-${jenkins.baseline}.x</artifactId>
-                <version>5015.vb_52d36583443</version>
+                <version>5054.v620b_5d2b_d5e6</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -57,8 +57,6 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-api</artifactId>
-            <!-- TODO: remove -->
-            <version>1377.vf606866f592b_</version>
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>

--- a/src/main/java/org/jenkinsci/plugins/compress_artifacts/CompressingArtifactManager.java
+++ b/src/main/java/org/jenkinsci/plugins/compress_artifacts/CompressingArtifactManager.java
@@ -24,6 +24,7 @@
 
 package org.jenkinsci.plugins.compress_artifacts;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.FilePath;
 import hudson.Launcher;
 import hudson.model.BuildListener;
@@ -42,7 +43,7 @@ final class CompressingArtifactManager extends ArtifactManager {
         onLoad(build);
     }
 
-    @Override public void onLoad(Run<?,?> build) {
+    @Override public void onLoad(@NonNull Run<?,?> build) {
         this.build = build;
     }
 

--- a/src/main/java/org/jenkinsci/plugins/compress_artifacts/CompressingArtifactManagerFactory.java
+++ b/src/main/java/org/jenkinsci/plugins/compress_artifacts/CompressingArtifactManagerFactory.java
@@ -24,6 +24,7 @@
 
 package org.jenkinsci.plugins.compress_artifacts;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.model.Run;
 import jenkins.model.ArtifactManager;
@@ -41,7 +42,7 @@ public final class CompressingArtifactManagerFactory extends ArtifactManagerFact
 
     @Extension public static final class DescriptorImpl extends ArtifactManagerFactoryDescriptor {
 
-        @Override public String getDisplayName() {
+        @Override @NonNull public String getDisplayName() {
             return "Compress Artifacts";
         }
 

--- a/src/main/java/org/jenkinsci/plugins/compress_artifacts/ZipStorage.java
+++ b/src/main/java/org/jenkinsci/plugins/compress_artifacts/ZipStorage.java
@@ -24,6 +24,7 @@
 
 package org.jenkinsci.plugins.compress_artifacts;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.FilePath;
 import hudson.Launcher;
 import hudson.model.BuildListener;
@@ -48,8 +49,6 @@ import java.util.logging.Logger;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
-import javax.annotation.Nonnull;
-
 import jenkins.util.VirtualFile;
 
 import org.springframework.web.util.UriUtils;
@@ -65,11 +64,8 @@ final class ZipStorage extends VirtualFile {
         // Use temporary file for writing, rename when done
         File tempArchive = new File(archive.getAbsolutePath() + ".writing.zip");
 
-        OutputStream os = new FileOutputStream(tempArchive);
-        try {
+        try (OutputStream os = new FileOutputStream(tempArchive)) {
             workspace.archive(ArchiverFactory.ZIP, os, new FilePath.ExplicitlySpecifiedDirScanner(artifacts));
-        } finally {
-            os.close();
         }
 
         tempArchive.renameTo(archive);
@@ -86,12 +82,12 @@ final class ZipStorage extends VirtualFile {
         this.archive = archive;
         this.path = path;
     }
-    
-    @Override public String getName() {
+
+    @Override @NonNull public String getName() {
         return path.replaceFirst("^(.+/)?([^/]+)/?$", "$2");
     }
-    
-    @Override public URI toURI() {
+
+    @Override @NonNull public URI toURI() {
         try {
             // If no scheme is provided, beginning of the path is parsed as the scheme causing validation problems.
             // Using some scheme to workaround that + prepending prefix to avoid empty URI path.
@@ -120,15 +116,14 @@ final class ZipStorage extends VirtualFile {
     }
 
     private boolean looksLikeDir() {
-        return path.length() == 0 || path.endsWith("/");
+        return path.isEmpty() || path.endsWith("/");
     }
-    
+
     @Override public boolean isDirectory() throws IOException {
         if (!looksLikeDir() || !archive.exists()) {
             return false;
         }
-        ZipFile zf = new ZipFile(archive);
-        try {
+        try (ZipFile zf = new ZipFile(archive)) {
             Enumeration<? extends ZipEntry> entries = zf.entries();
             while (entries.hasMoreElements()) {
                 ZipEntry entry = entries.nextElement();
@@ -138,28 +133,22 @@ final class ZipStorage extends VirtualFile {
                 }
             }
             return false;
-        } finally {
-            zf.close();
         }
     }
-    
+
     @Override public boolean isFile() throws IOException {
         if (looksLikeDir() || !archive.exists()) {
             return false;
         }
-        ZipFile zf = new ZipFile(archive);
-        try {
+        try (ZipFile zf = new ZipFile(archive)) {
             return zf.getEntry(path) != null;
-        } finally {
-            zf.close();
         }
     }
-    
+
     @Override public boolean exists() throws IOException {
         if (!archive.exists()) return false;
 
-        ZipFile zf = new ZipFile(archive);
-        try {
+        try (ZipFile zf = new ZipFile(archive)) {
             Enumeration<? extends ZipEntry> entries = zf.entries();
             while (entries.hasMoreElements()) {
                 ZipEntry entry = entries.nextElement();
@@ -169,18 +158,15 @@ final class ZipStorage extends VirtualFile {
                 }
             }
             return false;
-        } finally {
-            zf.close();
         }
     }
-    
-    @Override public VirtualFile[] list() throws IOException {
+
+    @Override @NonNull public VirtualFile[] list() throws IOException {
         if (!looksLikeDir() || !archive.exists()) {
             return new VirtualFile[0];
         }
-        ZipFile zf = new ZipFile(archive);
-        try {
-            Set<VirtualFile> files = new HashSet<VirtualFile>();
+        try (ZipFile zf = new ZipFile(archive)) {
+            Set<VirtualFile> files = new HashSet<>();
             Enumeration<? extends ZipEntry> entries = zf.entries();
             while (entries.hasMoreElements()) {
                 ZipEntry entry = entries.nextElement();
@@ -190,13 +176,11 @@ final class ZipStorage extends VirtualFile {
                     files.add(new ZipStorage(archive, pth));
                 }
             }
-            return files.toArray(new VirtualFile[files.size()]);
-        } finally {
-            zf.close();
+            return files.toArray(new VirtualFile[0]);
         }
     }
-    
-    @Override public VirtualFile child(String name) {
+
+    @Override @NonNull public VirtualFile child(@NonNull String name) {
         // TODO this is ugly; would be better to not require / on path
         ZipStorage f = new ZipStorage(archive, path + name + '/');
         try {
@@ -207,31 +191,25 @@ final class ZipStorage extends VirtualFile {
         }
         return new ZipStorage(archive, path + name);
     }
-    
+
     @Override public long length() throws IOException {
         if (!archive.exists()) return 0;
 
-        ZipFile zf = new ZipFile(archive);
-        try {
+        try (ZipFile zf = new ZipFile(archive)) {
             ZipEntry entry = zf.getEntry(path);
             return entry != null ? entry.getSize() : 0;
-        } finally {
-            zf.close();
         }
     }
-    
+
     @Override public long lastModified() throws IOException {
         if (!archive.exists()) return 0;
 
-        ZipFile zf = new ZipFile(archive);
-        try {
+        try (ZipFile zf = new ZipFile(archive)) {
             ZipEntry entry = zf.getEntry(path);
             return entry != null ? entry.getTime() : 0;
-        } finally {
-            zf.close();
         }
     }
-    
+
     @Override public boolean canRead() throws IOException {
         return true;
     }
@@ -257,10 +235,10 @@ final class ZipStorage extends VirtualFile {
 
         private static final Logger LOGGER = Logger.getLogger(EntryInputStream.class.getName());
 
-        private final @Nonnull ZipFile archive;
+        private final @NonNull ZipFile archive;
         private Exception acquired = new Exception("Opened by:");
 
-        private EntryInputStream(ZipFile archive, ZipEntry entry) throws IOException {
+        private EntryInputStream(@NonNull ZipFile archive, ZipEntry entry) throws IOException {
             super(archive.getInputStream(entry));
             this.archive = archive;
         }

--- a/src/test/java/org/jenkinsci/plugins/compress_artifacts/CompressArtifactsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/compress_artifacts/CompressArtifactsTest.java
@@ -43,6 +43,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import jenkins.model.ArtifactManagerFactory;
@@ -69,7 +70,7 @@ public class CompressArtifactsTest {
 
     @Before
     public void setUp() {
-        ArtifactManagerConfiguration amc = Jenkins.getInstance().getInjector().getInstance(ArtifactManagerConfiguration.class);
+        ArtifactManagerConfiguration amc = Jenkins.get().getInjector().getInstance(ArtifactManagerConfiguration.class);
         DescribableList<ArtifactManagerFactory, ArtifactManagerFactoryDescriptor> factories = amc.getArtifactManagerFactories();
         factories.clear();
         factories.add(new CompressingArtifactManagerFactory());
@@ -117,7 +118,7 @@ public class CompressArtifactsTest {
                 nested.mkdirs();
 
                 for (int i = 0; i < 2500; i++) {
-                    String name = "file." + Integer.toString(i) + ".txt";
+                    String name = "file." + i + ".txt";
                     ws.child(name).write(name, "UTF-8");
                     nested.child("nested." + name).write(name, "UTF-8");
                 }
@@ -132,11 +133,8 @@ public class CompressArtifactsTest {
 
         // read the content
         for (Run<FreeStyleProject, FreeStyleBuild>.Artifact a: artifacts) {
-            final InputStream artifactStream = build.getArtifactManager().root().child(a.relativePath).open();
-            try {
-                assertThat(IOUtils.toString(artifactStream), endsWith("txt"));
-            } finally {
-                artifactStream.close();
+            try (InputStream artifactStream = build.getArtifactManager().root().child(a.relativePath).open()) {
+                assertThat(IOUtils.toString(artifactStream, StandardCharsets.UTF_8), endsWith("txt"));
             }
         }
     }
@@ -170,12 +168,9 @@ public class CompressArtifactsTest {
         long length = archiveZip.length();
         assertThat(Functions.humanReadableByteSize(length), length, Matchers.greaterThanOrEqualTo(4L * 1024 * 1024 * 1024));
 
-        assertThat(build.getArtifacts(), Matchers.<Run<FreeStyleProject, FreeStyleBuild>.Artifact>iterableWithSize(artifactCount));
-        InputStream open = build.getArtifactManager().root().child("stuff" + (artifactCount - 1)).open();
-        try {
+        assertThat(build.getArtifacts(), Matchers.iterableWithSize(artifactCount));
+        try (InputStream open = build.getArtifactManager().root().child("stuff" + (artifactCount - 1)).open()) {
             IOUtils.copy(open, OutputStream.nullOutputStream());
-        } finally {
-            open.close();
         }
 
 
@@ -224,24 +219,18 @@ public class CompressArtifactsTest {
                 long length = 2L * 1024 * 1024 * 1024;
                 final FilePath src = new FilePath(Which.jarFile(Jenkins.class));
 
-                final OutputStream out = target.write();
-                try {
+                try (OutputStream out = target.write()) {
                     do {
                         IOUtils.copy(src.read(), out);
                     } while (target.length() < length);
-                } finally {
-                    out.close();
                 }
                 return true;
             }
         });
         p.getPublishersList().add(new ArtifactArchiver("**/*", null, false));
         FreeStyleBuild build = j.buildAndAssertSuccess(p);
-        InputStream out = build.getArtifactManager().root().child("out").open();
-        try {
+        try (InputStream out = build.getArtifactManager().root().child("out").open()) {
             IOUtils.copy(out, OutputStream.nullOutputStream());
-        } finally {
-             out.close();
         }
     }
 

--- a/src/test/java/org/jenkinsci/plugins/compress_artifacts/CompressingArtifactManagerFactoryTest.java
+++ b/src/test/java/org/jenkinsci/plugins/compress_artifacts/CompressingArtifactManagerFactoryTest.java
@@ -25,7 +25,6 @@ package org.jenkinsci.plugins.compress_artifacts;
 
 import hudson.Functions;
 import org.jenkinsci.plugins.workflow.ArtifactManagerTest;
-import org.jenkinsci.test.acceptance.docker.DockerImage;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.Rule;
@@ -36,16 +35,14 @@ public class CompressingArtifactManagerFactoryTest {
     @Rule
     public JenkinsRule r = new JenkinsRule();
 
-    private static DockerImage image;
-
     @BeforeClass
     public static void doPrepareImage() throws Exception {
-        image = ArtifactManagerTest.prepareImage();
+        ArtifactManagerTest.doPrepareImage();
     }
 
     @Test
     public void smokes() throws Exception {
-        ArtifactManagerTest.artifactArchiveAndDelete(r, new CompressingArtifactManagerFactory(), !Functions.isWindows(), image);
+        ArtifactManagerTest.artifactArchiveAndDelete(r, new CompressingArtifactManagerFactory(), !Functions.isWindows());
     }
 
 }

--- a/src/test/java/org/jenkinsci/plugins/compress_artifacts/ZipStorageTest.java
+++ b/src/test/java/org/jenkinsci/plugins/compress_artifacts/ZipStorageTest.java
@@ -24,6 +24,7 @@
 
 package org.jenkinsci.plugins.compress_artifacts;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.FilePath;
 import hudson.Functions;
 import hudson.Launcher;
@@ -35,6 +36,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -75,13 +77,13 @@ public class ZipStorageTest {
     }
 
     @Test public void basics() throws Exception {
-        FileUtils.writeStringToFile(new File(content, "top"), "top");
+        FileUtils.writeStringToFile(new File(content, "top"), "top", StandardCharsets.UTF_8);
         File dirF = new File(content, "dir");
         assertTrue(dirF.mkdir());
-        FileUtils.writeStringToFile(new File(dirF, "sub"), "sub");
+        FileUtils.writeStringToFile(new File(dirF, "sub"), "sub", StandardCharsets.UTF_8);
         new File(content, "dir/nested").mkdir();
 
-        Map<String,String> artifacts = new HashMap<String,String>();
+        Map<String,String> artifacts = new HashMap<>();
         artifacts.put("top", "top");
         artifacts.put("dir/sub", "dir/sub");
         artifacts.put("dir/nested", "dir/nested");
@@ -92,7 +94,7 @@ public class ZipStorageTest {
         doBasics(zs);
 
         // This is broken in VirtualFile#FileVF
-        assertEquals(null, zs.getParent());
+        assertNull(zs.getParent());
     }
 
     private void doBasics(VirtualFile vf) throws Exception {
@@ -144,31 +146,28 @@ public class ZipStorageTest {
     }
 
     private String read(VirtualFile vf) throws IOException {
-        InputStream open = vf.open();
-        try {
-            return IOUtils.toString(open);
-        } finally {
-            open.close();
+        try (InputStream open = vf.open()) {
+            return IOUtils.toString(open, StandardCharsets.UTF_8);
         }
     }
-    
+
     @Deprecated
     @Test public void globList() throws Exception {
         FileUtils.writeStringToFile(new File(content, "top"), "top");
         File dir1 = new File(content, "folder1");
         assertTrue(dir1.mkdir());
         FileUtils.writeStringToFile(new File(dir1, "file1.txt"), "file1Content");
-        
+
         File dir2 = new File(content,"folder2");
         assertTrue(dir2.mkdir());
         FileUtils.writeStringToFile(new File(dir2,"file2.log"), "file2Content");
-        
-        Map<String,String> artifacts = new HashMap<String,String>();
+
+        Map<String,String> artifacts = new HashMap<>();
         artifacts.put("top", "top");
         artifacts.put("folder1/file1.txt", "folder1/file1.txt");
         artifacts.put("folder2/file2.log", "folder2/file2.log");
         archive(artifacts);
-        
+
         doGlobList(canonical);
         doGlobList(zs);
     }
@@ -192,7 +191,7 @@ public class ZipStorageTest {
 
     @Test public void readError() throws Exception {
         new File(content, "dir").mkdir();
-        Map<String,String> artifacts = new HashMap<String,String>();
+        Map<String,String> artifacts = new HashMap<>();
         artifacts.put("dir", "dir");
         archive(artifacts);
 
@@ -205,7 +204,7 @@ public class ZipStorageTest {
     private void doReadNonexistingDir(VirtualFile vf) {
         try {
             VirtualFile child = vf.child("there_is_none");
-            fail("expected " + child + " to not exist but got: " + IOUtils.toString(child.open()));
+            fail("expected " + child + " to not exist but got: " + IOUtils.toString(child.open(), StandardCharsets.UTF_8));
         } catch (IOException ex) {
             // good
         }
@@ -213,14 +212,14 @@ public class ZipStorageTest {
     private void doReadDir(VirtualFile vf) throws IOException {
         try {
             VirtualFile child = vf.list()[0];
-            fail("expected " + child + " to be a directory but got: " + IOUtils.toString(child.open()));
+            fail("expected " + child + " to be a directory but got: " + IOUtils.toString(child.open(), StandardCharsets.UTF_8));
         } catch (IOException ex) {
             // good
         }
     }
 
     @Test public void operateOnNonexistingFiles() throws Exception {
-        archive(new HashMap<String,String>());
+        archive(new HashMap<>());
 
         doRead(canonical);
         doRead(zs);
@@ -232,18 +231,20 @@ public class ZipStorageTest {
 
     @Test
     public void avoidZipExceptionWhileWriting() throws Exception {
-        FileUtils.writeStringToFile(new File(content, "file"), "content");
+        FileUtils.writeStringToFile(new File(content, "file"), "content", StandardCharsets.UTF_8);
 
         final Entry<String, String> validArtifact = Collections.singletonMap("file", "file").entrySet().iterator().next();
 
         // Simulate archiving that takes forever serving valid artifact and then block forever on the next.
-        final Map<String,String> artifacts = new HashMap<String,String>() {
+        final Map<String,String> artifacts = new HashMap<>() {
             @Override
+            @NonNull
             public Set<Map.Entry<String, String>> entrySet() {
-                return new HashSet<Map.Entry<String, String>>() {
+                return new HashSet<>() {
                     @Override
+                    @NonNull
                     public Iterator<Map.Entry<String, String>> iterator() {
-                        return new Iterator<Map.Entry<String, String>>() {
+                        return new Iterator<>() {
                             private boolean block = false;
 
                             public boolean hasNext() {
@@ -331,7 +332,7 @@ public class ZipStorageTest {
         File subdir = new File(content, dirname);
         subdir.mkdirs();
 
-        FileUtils.writeStringToFile(new File(subdir, filename), "content");
+        FileUtils.writeStringToFile(new File(subdir, filename), "content", StandardCharsets.UTF_8);
 
         String fullname = dirname + "/" + filename;
         archive(Collections.singletonMap(fullname, fullname));


### PR DESCRIPTION
## Require Jenkins 2.504.1 and Jakarta EE 9

Jenkins 2.504.1 provides Jakarta EE 9, Eclipse Jetty 12, Spring Security 6, and Java 17.

* Bump baseline and dependencies
* Replace docker-fixtures with testcontainers (https://github.com/jenkinsci/docker-fixtures/pull/122#issuecomment-3046351724)
* Use Java 17 features, remove deprecations, cleanup

### Testing done

`mvn clean verify`

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed